### PR TITLE
Min indexed level

### DIFF
--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -21,6 +21,7 @@ class ConfigLoader(object):
     stop_urls = None
     strategy = None
     strip_chars = None
+    min_indexed_level = 0
 
     def __init__(self):
         if os.environ['CONFIG'] is None:
@@ -41,6 +42,7 @@ class ConfigLoader(object):
             'custom_settings',
             'index_name',
             'index_prefix',
+            'min_indexed_level',
             'selectors',
             'selectors_exclude',
             'start_urls',

--- a/src/strategies/default_strategy.py
+++ b/src/strategies/default_strategy.py
@@ -82,15 +82,18 @@ class DefaultStrategy(AbstractStrategy):
             hierarchy = previous_hierarchy.copy()
 
             # Update the hierarchy for each new header
+            current_level_int = int(current_level[3:]) if current_level != 'text' else 6 # 6 > lvl5
             if current_level != 'text':
                 hierarchy[current_level] = self.get_text(node)
                 anchors[current_level] = self.get_anchor(node)
 
-                current_level_int = int(current_level[3:])
                 for index in range(current_level_int + 1, 6):
                     hierarchy['lvl' + str(index)] = None
                     anchors['lvl' + str(index)] = None
                 previous_hierarchy = hierarchy
+
+            if current_level_int < self.config.min_indexed_level:
+                continue
 
             # Getting the element anchor as the closest one
             anchor = None


### PR DESCRIPTION
For instance, if you put min_indexed_level=1, it won't index the `lvl0`-only records

Fix #7
