### PR TITLE
feat(boilerplate): Add a `run` boilerplate script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 crawling_data
 src/*.pyc
 src/strategies/*.pyc
-run.sh
+run
 .DS_Store

--- a/run.boilerplate
+++ b/run.boilerplate
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+cd "$(dirname "$BASH_SOURCE")"
+repo_root=$(pwd)
+
+# HOW TO USE:
+# Build a Docker development image:
+# $ docker build -t algolia/documentation-scrapper-dev -f Dockerfile.dev .
+#
+# Then copy this file as `./run` at the project root (it is ignored by git) and
+# change the following config. After it's done, just start `./run` to start
+# scraping and indexing.
+api_key="apiKey"
+app_id="appID"
+config_name="configName"
+container_name="containerName"
+prefix="prefix_"
+# NO NEED TO CHANGE ANYTHING AFTER THIS LINE
+
+config=$(cat "${repo_root}/configs/${config_name}.json")
+mount_path="${repo_root}/src"
+
+docker stop $container_name 2>/dev/null
+docker rm $container_name 2>/dev/null
+
+docker run \
+    -e APPLICATION_ID=$app_id \
+    -e API_KEY=$api_key \
+    -e INDEX_PREFIX=$prefix \
+    -e CONFIG="$config" \
+    -v "${mount_path}:/root/src" \
+    --name $container_name \
+    -t algolia/documentation-scrapper-dev \
+    /root/run


### PR DESCRIPTION
I've added a `run.boilerplate` file that you can edit by filling your
own config options. It will allow you to easily run the Dockerized dev
version locally, to test your scrapper.
