### PR TITLE
feat(allowed_domain): Unique and map on the allowed_domains

### DIFF
--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -77,10 +77,25 @@ class ConfigLoader(object):
         if not isinstance(data.get('stop_urls'), list):
             data['stop_urls'] = [data['stop_urls']]
 
-        # Allowed domains uses start url if empty
+        # Build default allowed_domains from start_urls and stop_urls
         if not data.get('allowed_domains'):
-            parsed_uri = urlparse(data.get('start_urls')[0])
-            data['allowed_domains'] = parsed_uri.netloc
+            if not data.get('allowed_domains'):
+                def get_domain(url):
+                    """ Return domain name from url """
+                    return urlparse(url).netloc
+
+                # Concatenating both list, being careful that they can be None
+                all_urls = data.get('start_urls', []) + data.get('stop_urls', [])
+                # Getting the list of domains for each of them
+                all_domains = [get_domain(_) for _ in all_urls]
+                # Removing duplicates
+                all_domains_unique = []
+                for domain in all_domains:
+                    if domain in all_domains_unique:
+                        continue
+                    all_domains_unique.append(domain)
+
+                data['allowed_domains'] = all_domains_unique
 
         # Allowed domains must be an array
         if not isinstance(data.get('allowed_domains'), list):

--- a/src/config_loader_test.py
+++ b/src/config_loader_test.py
@@ -19,7 +19,7 @@ class TestInit:
             'selectors': 'selectors',
             'selectors_exclude': 'selectors_exclude',
             'start_urls': 'start_urls',
-            'stop_urls': 'stop_urls',
+            'stop_urls': 'http://www.stopurl.com/',
             'strategy': 'strategy',
             'strip_chars': 'strip_chars'
         }
@@ -122,12 +122,12 @@ class TestInit:
         with pytest.raises(ValueError):
             ConfigLoader()
 
-    def test_allowed_domains_uses_start_url_as_default(self):
-        """ Should use domain of start_urls for allowed_domains if none is set
-        """
+    def test_allowed_domains_start(self):
+        """ Should populate allowed_domains from start_urls """
         # Given
         self.config({
             'start_urls': 'http://www.foo.bar/',
+            'stop_urls': [],
             'allowed_domains': None
         })
 
@@ -136,3 +136,37 @@ class TestInit:
 
         # Then
         assert actual.allowed_domains == ['www.foo.bar']
+    
+    def test_allowed_domains_start_stop(self):
+        """ Should populate allowed_domains from both start and stop urls """
+        # Given
+        self.config({
+            'start_urls': 'http://www.foo.bar/',
+            'stop_urls': 'http://www.algolia.com/',
+            'allowed_domains': None
+        })
+
+        # When
+        actual = ConfigLoader()
+
+        # Then
+        assert actual.allowed_domains == ['www.foo.bar', 'www.algolia.com']
+
+    def test_allowed_domains_unique(self):
+        """ Should populate a list of unique domains """
+        # Given
+        self.config({
+            'start_urls': 'http://www.foo.bar/',
+            'stop_urls': [
+                'http://www.algolia.com/',
+                'http://www.foo.bar/'
+            ],
+            'allowed_domains': None
+        })
+
+        # When
+        actual = ConfigLoader()
+
+        # Then
+        assert actual.allowed_domains == ['www.foo.bar', 'www.algolia.com']
+


### PR DESCRIPTION
I've added tests to the config_loader, as well as guessing some
default values (`allowed_domains` from `start_urls`) and being more
lenient on others (accepting string instead of array with one value).
