### PR TITLE
fix(strategy): Set `default` as the default strategy

### DIFF
--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -99,6 +99,7 @@ class ConfigLoader(object):
         if not isinstance(data.get('allowed_domains'), list):
             data['allowed_domains'] = [data['allowed_domains']]
 
-
+        # Set default strategy
+        data['strategy'] = data.get('strategy') or 'default'
 
         return data

--- a/src/config_loader_test.py
+++ b/src/config_loader_test.py
@@ -170,3 +170,15 @@ class TestInit:
         # Then
         assert actual.allowed_domains == ['www.foo.bar', 'www.algolia.com']
 
+    def test_default_strategy(self):
+        """ Should use default strategy if none is passed """
+        self.config({
+            'strategy': None
+        })
+
+        # When
+        actual = ConfigLoader()
+
+        # Then
+        assert actual.strategy == 'default'
+


### PR DESCRIPTION
Just setting `default` as the default strategy so we do not have to put it in the config files (as this is the only one we actually have)
