### PR TITLE
config(wbwgn): Add WBWGN config

### DIFF
--- a/configs/wbwgn.json
+++ b/configs/wbwgn.json
@@ -1,0 +1,23 @@
+{
+  "index_name": "wbwgn",
+  "start_urls": [
+    "https://digital.wbwgn.com/"
+  ],
+  "stop_urls": [],
+  "selectors_exclude": [],
+  "selectors": {
+    "lvl0": {
+      "selector": "//*[contains(@class, 'sidebar')]/*/a[@class='heading active']|//*[contains(@class, 'sidebar')]/*/*/a[@class='active']/../../preceding::li[1]/a",
+      "type": "xpath",
+      "searchable": false,
+      "global": true
+    },
+    "lvl1": ".container h1",
+    "lvl2": ".container h2",
+    "text": ".container p"
+  },
+  "comments": [
+    "The lvl0 will first try to select the active headings in the sidebar (Homepage, Core, Page, Code Pinball)",
+    "If none is found, it will look for active pages, and go up the tree to find the matching heading"
+  ]
+}


### PR DESCRIPTION
https://digital.wbwgn.com/

I'm not completly happy with this one. 

I cannot grab the Core / Page / Code Pinball from the sidebar.
![image](https://cloud.githubusercontent.com/assets/283419/12367081/cffe5964-bbdf-11e5-952e-43cc1f912093.png)

The currently selected page is not marked with any special class so I have no idea in which section I am. So I simply used the main page h1/h2 and p.
![image](https://cloud.githubusercontent.com/assets/283419/12367107/fe2f2ac0-bbdf-11e5-93c6-6a794f18b32b.png)

Only the url could indicate the hierarchy (`/core`, `/pages`,`/code-pinball`) but we have no way to use it at the moment.
