### PR TITLE
Fix the detection of the `js_render` parameter from the JSON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN pip3 install -e ./splash/
 
 # Copy DocSearch files
 COPY docker/run /root/
+COPY docker/check_js_render.py /root/
 COPY src /root/src
 RUN chmod +x /root/run
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -36,6 +36,7 @@ RUN pip3 install -e ./splash/
 
 # Copy DocSearch files
 COPY docker/run /root/
+COPY docker/check_js_render.py /root/
 COPY docker/test /root/
 RUN chmod +x /root/test
 RUN chmod +x /root/run

--- a/docker/check_js_render.py
+++ b/docker/check_js_render.py
@@ -1,0 +1,10 @@
+import json
+import os
+import sys
+
+config = json.loads(os.environ['CONFIG'])
+
+if 'js_render' in config and config['js_render']:
+        sys.exit(0)
+else:
+        sys.exit(1)

--- a/docker/run
+++ b/docker/run
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-echo $CONFIG | grep -qF '"js_render": true'
+python /root/check_js_render.py
 
 if [ "$?" -eq 0 ]
 then
   splash --proxy-profiles-path /etc/splash/proxy-profiles \
          --js-profiles-path /etc/splash/js-profiles       \
          --filters-path /etc/splash/filters               \
-         --lua-package-path /etc/splash/lua_modules/?.lua \
-         > /dev/null 2>&1 &
+         --lua-package-path /etc/splash/lua_modules/?.lua 2>&1 &
+
+  while ! nc -z localhost 8050; do
+    sleep 1
+    ((c++)) && ((c==10)) && echo "Splash has not started" && break
+  done
 fi
-python /root/src/index.py
+
+python /root/src/index.py 2>&1


### PR DESCRIPTION
The `js_render` parameter was previously checked using a simple regexp with
grep. It resulted in false negative detections.

We now check at the JSON level using a Python script.

Moreover, we now wait for the Splash instance to start before running the
DocSearch instance.
