### PR TITLE
Split the Docker image to reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,10 @@
-FROM ubuntu:14.04
+FROM algolia/base-documentation-scrapper
 MAINTAINER Algolia <documentationsearch@algolia.com>
-
-# Install DocSearch dependencies
-RUN apt-get update -y && apt-get install -y \
-      python-pip  \
-      python-dev  \
-      python-lxml \
-      libffi-dev  \
-      libssl-dev  \
-      git
-RUN pip install scrapy
-RUN pip install scrapyjs
-RUN pip install algoliasearch
-
-# Put everything in /root
-WORKDIR /root
-
-# Install and configure Splash
-RUN git clone https://github.com/scrapinghub/splash
-RUN ./splash/dockerfiles/splash/provision.sh \
-    prepare_install                          \
-    install_msfonts                          \
-    install_builddeps                        \
-    install_deps                             \
-    install_extra_fonts                      \
-    install_pyqt5                            \
-    install_python_deps
-RUN pip3 install -e ./splash/
 
 # Copy DocSearch files
 COPY docker/run /root/
 COPY docker/check_js_render.py /root/
 COPY src /root/src
 RUN chmod +x /root/run
-
-# Create volumes for Splash
-VOLUME [                          \
-    "/etc/splash/proxy-profiles", \
-    "/etc/splash/js-profiles",    \
-    "/etc/splash/filters",        \
-    "/etc/splash/lua_modules"     \
-]
 
 ENTRYPOINT ["/root/run"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,37 @@
+FROM ubuntu:14.04
+MAINTAINER Algolia <documentationsearch@algolia.com>
+
+# Install DocSearch dependencies
+RUN apt-get update -y && apt-get install -y \
+      python-pip  \
+      python-dev  \
+      python-lxml \
+      libffi-dev  \
+      libssl-dev  \
+      git
+RUN pip install scrapy
+RUN pip install scrapyjs
+RUN pip install algoliasearch
+
+# Put everything in /root
+WORKDIR /root
+
+# Install and configure Splash
+RUN git clone https://github.com/scrapinghub/splash
+RUN ./splash/dockerfiles/splash/provision.sh \
+    prepare_install                          \
+    install_msfonts                          \
+    install_builddeps                        \
+    install_deps                             \
+    install_extra_fonts                      \
+    install_pyqt5                            \
+    install_python_deps
+RUN pip3 install -e ./splash/
+
+# Create volumes for Splash
+VOLUME [                          \
+    "/etc/splash/proxy-profiles", \
+    "/etc/splash/js-profiles",    \
+    "/etc/splash/filters",        \
+    "/etc/splash/lua_modules"     \
+]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,36 +3,10 @@
 # - Do not COPY ./src
 # - Do not define an ENTRYPOINT
 
-FROM ubuntu:14.04
+FROM algolia/base-documentation-scrapper
 MAINTAINER Algolia <documentationsearch@algolia.com>
 
-# Install DocSearch dependencies
-RUN apt-get update -y && apt-get install -y \
-      python-pip  \
-      python-dev  \
-      python-lxml \
-      libffi-dev  \
-      libssl-dev  \
-      git
-RUN pip install scrapy
-RUN pip install scrapyjs
-RUN pip install algoliasearch
-RUN pip install pytest
-
-# Put everything in /root
-WORKDIR /root
-
-# Install and configure Splash
-RUN git clone https://github.com/scrapinghub/splash
-RUN ./splash/dockerfiles/splash/provision.sh \
-    prepare_install                          \
-    install_msfonts                          \
-    install_builddeps                        \
-    install_deps                             \
-    install_extra_fonts                      \
-    install_pyqt5                            \
-    install_python_deps
-RUN pip3 install -e ./splash/
+RUN pip2 install pytest
 
 # Copy DocSearch files
 COPY docker/run /root/
@@ -40,11 +14,3 @@ COPY docker/check_js_render.py /root/
 COPY docker/test /root/
 RUN chmod +x /root/test
 RUN chmod +x /root/run
-
-# Create volumes for Splash
-VOLUME [                          \
-    "/etc/splash/proxy-profiles", \
-    "/etc/splash/js-profiles",    \
-    "/etc/splash/filters",        \
-    "/etc/splash/lua_modules"     \
-]


### PR DESCRIPTION
Since we've added the Splash instance to our Docker image, the build time has
increased a lot because of all the new dependencies it relies on.

This commit splits the Docker image by creating a `base` image containing the
Splash instance and all its dependencies. The Docker image that we'll need to
build everyday is just adding our `documentation-scrapper` code.
