### PR TITLE
config(reindex): Adding reindex.io config

### DIFF
--- a/configs/reindex.json
+++ b/configs/reindex.json
@@ -1,0 +1,22 @@
+{
+  "index_name": "reindex",
+  "start_urls": [
+    "https://www.reindex.io/docs/"
+  ],
+  "stop_urls": [
+  ],
+  "selectors_exclude": [],
+  "selectors": {
+    "lvl0": {
+      "searchable": false,
+      "selector": "(//li/a[contains(@class, 'active')]/../../../a[1]|//li/a[contains(@class, 'active')])[1]",
+      "type": "xpath",
+      "global": true
+    },
+    "lvl1": ".markdown h1",
+    "lvl2": ".markdown h2",
+    "lvl3": ".markdown h3",
+    "lvl4": ".markdown h4",
+    "text": ".markdown p"
+  }
+}


### PR DESCRIPTION
The sidebar menu can have up to two levels. What the `lvl0` selector
does is first trying to get the currently selected page, and if it is
a subpage then grab its parent category. If that fails, it will get
the currently selected link. I'm not searching into that field.

Other selectors are classical h1/h2. For pages that are at the top of
the hierarchy, the `lvl0` and `lvl1` will be identical.

![image](https://cloud.githubusercontent.com/assets/283419/12555516/dee44c32-c381-11e5-8c94-cba58cc9ee28.png)
