### PR TITLE
config(canvasjs): Add config for canvasjs

### DIFF
--- a/configs/canvasjs.json
+++ b/configs/canvasjs.json
@@ -1,0 +1,27 @@
+{
+  "index_name": "canvasjs",
+  "start_urls": [
+    "http://canvasjs.com/docs/charts/"
+  ],
+  "stop_urls": [
+    "http://canvasjs.com/docs/(.*)/?replytocom=(.*)",
+    "http://canvasjs.com/docs/(.*)/#comment-(.*)",
+    "http://canvasjs.com/docs/(.*)/#respond"
+  ],
+  "selectors_exclude": [
+    ".modal",
+    ".nav-collapse",
+    ".comment-respond",
+    "#comments"
+  ],
+  "selectors": {
+    "lvl0": {
+      "selector": ".nodeSel",
+      "global": true,
+      "searchable": false
+    },
+    "lvl1": "h2, h3",
+    "text": "p, li"
+  },
+  "js_render": true
+}


### PR DESCRIPTION
Config for http://canvasjs.com/docs/charts/

Their documentation has very deep nesting, but the markup does not contain any specific way to check which level we are in. So I only used the currently selected element in the sidebar as the `lvl0`, but made it not searchable.

![image](https://cloud.githubusercontent.com/assets/283419/12621392/acd7da88-c520-11e5-921f-d5849cabfff3.png)

The markup does not contain any semantic class name, so it was either to blacklist parts of the page (header, comments, modals) than targetting the main content directly.

In the end, it is no so bad but could be greatly improved with better markup. We contacted the owner and they told us that this is a big work on their side so they're asking that we release what we have for now.

![image](https://cloud.githubusercontent.com/assets/283419/12621487/0f1a42c6-c521-11e5-9b7d-5b7e1423ba0a.png)
