### PR TITLE
fix(url): Stop searching in url and anchor

### DIFF
--- a/src/strategies/default_strategy.py
+++ b/src/strategies/default_strategy.py
@@ -190,8 +190,6 @@ class DefaultStrategy(AbstractStrategy):
         if 'content' in self.config.selectors and self.config.selectors['content']['searchable']:
             attributes_to_index.append('content')
 
-        attributes_to_index.append('url,anchor')
-
         settings = {
             'attributesToIndex': attributes_to_index,
             'attributesToRetrieve': [

--- a/src/strategies/default_strategy_test.py
+++ b/src/strategies/default_strategy_test.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 
+
 SELECTORS = {
     "lvl0": "h1",
     "lvl1": "h2",
@@ -918,8 +919,7 @@ class TestGetSettings:
                 'unordered(hierarchy.lvl0)',
                 'unordered(hierarchy.lvl1)',
                 'unordered(hierarchy.lvl2)',
-                'content',
-                'url,anchor'
+                'content'
         ]
 
         assert settings['attributesToIndex'] == expected_settings
@@ -948,8 +948,7 @@ class TestAllowToBypassOneOrMoreLevels:
             'unordered(hierarchy_radio.lvl2)',
             'unordered(hierarchy.lvl1)',
             'unordered(hierarchy.lvl2)',
-            'content',
-            'url,anchor'
+            'content'
         ]
 
         assert settings['attributesToIndex'] == expected_settings


### PR DESCRIPTION
I think those where only added so we could add highlight to it. But
actually, it is no longer necessary to add fields to
`attributesToIndex` in order for them to be highlighted if they are
also in `attributesToHighlight`.

Fixes #82
