### PR TITLE
test(min_indexed_level): Add test for `min_indexed_level`.

### DIFF
--- a/src/config_loader_test.py
+++ b/src/config_loader_test.py
@@ -171,6 +171,7 @@ class TestInit:
         assert actual.allowed_domains == ['www.foo.bar', 'www.algolia.com']
 
     def test_start_url_should_add_default_page_rank_and_tags(self):
+        """ Should add default values for page_rank and tags """
         # Given
         self.config({
             'start_urls': [{"url": "http://www.foo.bar/"}]
@@ -184,6 +185,7 @@ class TestInit:
         assert actual.start_urls[0]['page_rank'] == 0
 
     def test_start_url_should_be_transform_to_object_if_string(self):
+        """ Should accept strings for start_urls as well as objects """
         # Given
         self.config({
             'start_urls': ['http://www.foo.bar/']
@@ -250,3 +252,11 @@ class TestInit:
 
         # Then
         assert actual.selectors_exclude == ['.test']
+
+    def test_use_anchor_default(self):
+        """ Should set the `use_anchors` parameter to True by default """
+        # When
+        actual = ConfigLoader()
+
+        # Then
+        assert actual.use_anchors is True

--- a/src/strategies/default_strategy_test.py
+++ b/src/strategies/default_strategy_test.py
@@ -175,7 +175,6 @@ class TestGetRecordsFromDom:
         assert actual[0]['hierarchy']['lvl1'] is None
         assert actual[0]['hierarchy']['lvl2'] is None
 
-
 class TestGetHierarchyRadio:
 
     def test_toplevel(self):
@@ -385,7 +384,7 @@ class TestGetLevelWeight:
         assert strategy.get_level_weight('lvl5') == 50
         assert strategy.get_level_weight('text') == 0
 
-class TestGetRecordsFromDom2:
+class TestGetRecordsFromDom:
     def test_text_with_only_three_levels(self):
         # Given
         strategy = get_strategy({
@@ -653,7 +652,6 @@ class TestGetRecordsFromDomWithXpath:
         assert actual[0]['hierarchy']['lvl2'] is None
         assert actual[0]['content'] == 'text'
 
-
 class TestGetRecordsFromDomWithDefaultValue:
     def test_default_value(self):
         # Given
@@ -894,6 +892,39 @@ class TestGetRecordsFromDomWithOldTestSelector:
         assert actual[3]['hierarchy']['lvl2'] == 'Baz'
         assert actual[3]['content'] == 'text'
 
+class TestGetRecordsFromDomWithMinIndexedLevel:
+    def test_test_default_value_with_global(self):
+        """ Should be able to not index the n first levels """
+        # Given
+        strategy = get_strategy({
+            'selectors': {
+                'lvl0': 'h1',
+                'lvl1': 'h2',
+                'lvl2': 'h3',
+                'content': 'p',
+            },
+            'min_indexed_level': 2
+        })
+
+        strategy.dom = lxml.html.fromstring("""
+        <html><body>
+            <h1>Foo</h1>
+            <h2>Bar</h2>
+            <h3>Baz</h3>
+            <p>text</p>
+        </body></html>
+        """)
+
+        # When
+        actual = strategy.get_records_from_dom()
+
+        # Then
+        assert len(actual) == 2
+        assert actual[0]['type'] == 'lvl2'
+        assert actual[0]['hierarchy']['lvl0'] == 'Foo'
+        assert actual[0]['hierarchy']['lvl1'] == 'Bar'
+        assert actual[0]['hierarchy']['lvl2'] == 'Baz'
+        assert actual[1]['type'] == 'content'
 
 class TestGetSettings:
     def test_get_settings(self):


### PR DESCRIPTION
I've added a simple test that checks that for a defined value of
`min_indexed_level`, the `n` first levels are correctly not indexed.

I've also added a few Docstring to some tests where it was missing.

The `get_records_from_dom` is a huge monster. We'll have to split it
one day, it is getting more and more complex to understand (I'm sure
we could simplify it by learning a bit more of python, I can't believe
the language forces us all those loops).

Fixes #29
