### PR TITLE
fix(env): script is python2

### DIFF
--- a/deployer/deploy
+++ b/deployer/deploy
@@ -10,6 +10,6 @@ cd /tmp/docsearch_deploy/scraper/deployer/
 git clone --depth 1 --branch master git@github.com:algolia/docsearch-configs.git public
 git clone --depth 1 --branch master git@github.com:algolia/docsearch-configs-private.git private
 
-python /tmp/docsearch_deploy/scraper/deployer/src/index.py
+./tmp/docsearch_deploy/scraper/deployer/src/index.py
 
 rm -rf /tmp/docsearch_deploy

--- a/src/index.py
+++ b/src/index.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python2
+
 """
 documentationSearch scrapper main entry point
 """


### PR DESCRIPTION
If `python --version` is 3 then the script will be ran using python 3
which is not the one you are looking for.

Random stackexchange answer used:
http://unix.stackexchange.com/questions/62910/correct-handling-of-
python2-and-python3
