### PR TITLE
Implement commands to update/delete emails

### DIFF
--- a/cli/src/commands/modify_emails.py
+++ b/cli/src/commands/modify_emails.py
@@ -1,0 +1,57 @@
+import os
+from os import path
+import subprocess as sp
+
+from .abstract_command import AbstractCommand
+
+from deployer.src.emails import add, delete
+
+
+def _ensure_configs_private():
+    # Check the presence of configs-private or clone it.
+    p = '/tmp/docsearch_deploy/scraper/deployer'
+    try:
+        os.makedirs(p)
+    except OSError:
+        pass
+    old_dir = os.getcwd()
+    os.chdir(p)
+    if not path.isdir('private'):
+        sp.call(['git', 'clone', '--depth', '1', '--branch', 'master',
+                 'git@github.com:algolia/docsearch-configs-private.git',
+                 'private'])
+    os.chdir(old_dir)
+    return p
+
+
+class UpdateEmails(AbstractCommand):
+    def get_name(self):
+        return 'emails:update'
+
+    def get_description(self):
+        return 'Add or update contact emails'
+
+    def get_options(self):
+        return [{'name': 'configs...', 'description': 'name of the docsearch you want to update contact emails'}]
+
+    def run(self, args):
+        p = _ensure_configs_private()
+        for config in args:
+            add(config, path.join(p, 'private'))
+
+
+class DeleteEmails(AbstractCommand):
+    def get_name(self):
+        return 'emails:delete'
+
+    def get_description(self):
+        return 'Delete contact emails'
+
+    def get_options(self):
+        return [{'name': 'configs...', 'description': 'name of the docsearch you want to delete contact emails'}]
+
+    def run(self, args):
+        p = _ensure_configs_private()
+        for config in args:
+            delete(config,  path.join(p, 'private'))
+

--- a/cli/src/index.py
+++ b/cli/src/index.py
@@ -24,6 +24,7 @@ from .commands.run_config_docker import RunConfigDocker
 from .commands.run_doctor import RunDoctor
 from .commands.reindex_connector import ReindexConnector
 from .commands.generate_email import GenerateEmail
+from .commands.modify_emails import UpdateEmails, DeleteEmails
 
 if not path.isfile(env_file):
     print("")
@@ -97,6 +98,8 @@ if ADMIN:
     cmds.append(DeployDockerDoctorImages())
     cmds.append(RunDoctor())
     cmds.append(BuildDockerDoctor())
+    cmds.append(UpdateEmails())
+    cmds.append(DeleteEmails())
 
 
 def print_usage(no_ansi=False):

--- a/deployer/src/emails.py
+++ b/deployer/src/emails.py
@@ -45,22 +45,20 @@ def _prompt_command(emails):
     return emails
 
 
-def _retrieve(config_name):
-    base_dir = path.dirname(__file__)
-    txt = path.join(base_dir, '..', 'private', 'infos', config_name + '.txt')
+def _retrieve(config_name, config_dir):
+    txt = path.join(config_dir, 'infos', config_name + '.txt')
     if path.isfile(txt):
         with open(txt, 'r') as f:
             return [l.strip() for l in f.readlines()]
     return []
 
 
-def _commit_push(config_name, action):
-    dir_ = path.join(path.dirname(__file__), '..', 'private')
+def _commit_push(config_name, action, config_dir):
     txt = path.join('infos', config_name + '.txt')
     commit_message = 'deploy: {} emails for {}'.format(action, config_name)
 
     old_dir = os.getcwd()
-    os.chdir(dir_)
+    os.chdir(config_dir)
 
     with open(os.devnull, 'w') as dev_null:
         sp.call(['git', 'add', txt], stdout=dev_null, stderr=sp.STDOUT)
@@ -70,15 +68,14 @@ def _commit_push(config_name, action):
     os.chdir(old_dir)
 
 
-def _write(emails, config_name):
-    base_dir = path.dirname(__file__)
-    txt = path.join(base_dir, '..', 'private', 'infos', config_name + '.txt')
+def _write(emails, config_name, config_dir):
+    txt = path.join(config_dir, 'infos', config_name + '.txt')
     with open(txt, 'w') as f:
         f.write('\n'.join(emails))
 
 
-def _prompt_emails(config_name):
-    emails = _retrieve(config_name)
+def _prompt_emails(config_name, config_dir):
+    emails = _retrieve(config_name, config_dir)
 
     while True:
         old = emails[:]
@@ -89,15 +86,22 @@ def _prompt_emails(config_name):
     return emails
 
 
-def add(config_name):
-    emails = _prompt_emails(config_name)
-    _write(emails, config_name)
-    _commit_push(config_name, 'Update')
+def add(config_name, config_dir=None):
+    if config_dir is None:
+        basedir = path.dirname(__file__)
+        config_dir = path.join(basedir, '..', 'private')
+
+    emails = _prompt_emails(config_name, config_dir)
+    _write(emails, config_name, config_dir)
+    _commit_push(config_name, 'Update', config_dir)
 
 
-def delete(config_name):
-    base_dir = path.dirname(__file__)
-    txt = path.join(base_dir, '..', 'private', 'infos', config_name + '.txt')
+def delete(config_name, config_dir=None):
+    if config_dir is None:
+        basedir = path.dirname(__file__)
+        config_dir = path.join(basedir, '..', 'private')
+
+    txt = path.join(config_dir, 'infos', config_name + '.txt')
     if path.isfile(txt) and helpers.confirm('Delete emails for {}'.format(config_name)):
         os.remove(txt)
-        _commit_push(config_name, 'Delete')
+        _commit_push(config_name, 'Delete', config_dir)


### PR DESCRIPTION
Implement two new commands available to ADMIN only:
- `emails:update` to add/update
- `emails:delete` to... delete

The folder used to clone `docsearch-configs-private` is the same that the one used by deploy.

Implements https://github.com/algolia/docsearch-scraper/issues/295
