### PR TITLE
fix(scraping): Fixed SSLv3 related issues

### DIFF
--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -47,6 +47,7 @@ PROCESS = CrawlerProcess({
     # 'LOG_LEVEL': 'DEBUG',
     'USER_AGENT': 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)',
     'DOWNLOADER_MIDDLEWARES': {'__main__.CustomMiddleware': 900},# Need to be > 600 to be after the redirectMiddleware
+    'DOWNLOADER_CLIENTCONTEXTFACTORY': 'scrapy_patch.CustomContextFactory'
 })
 
 PROCESS.crawl(

--- a/scraper/src/scrapy_patch.py
+++ b/scraper/src/scrapy_patch.py
@@ -1,4 +1,6 @@
 import scrapy.utils.request
+from OpenSSL import SSL
+from scrapy.core.downloader.contextfactory import ScrapyClientContextFactory
 
 # patching scrappy to avoid canonalizing urls in the reactor
 def request_fingerprint_non_canonicalize(request, include_headers=None):
@@ -21,3 +23,14 @@ def request_fingerprint_non_canonicalize(request, include_headers=None):
 
 
 scrapy.utils.request.request_fingerprint = request_fingerprint_non_canonicalize
+
+# following https://github.com/scrapy/scrapy/issues/1429#issuecomment-131782133
+# this seems to be the best option to avoid SSLv3 issues
+class CustomContextFactory(ScrapyClientContextFactory):
+    """
+    Custom context factory that allows SSL negotiation.
+    """
+
+    def __init__(self):
+        # Use SSLv23_METHOD so we can use protocol negotiation
+        self.method = SSL.SSLv23_METHOD


### PR DESCRIPTION
This fixes the error we get while crawling enlightment's doc:

```
2016-06-12 09:58:15 [scrapy] ERROR: Error downloading <GET
https://docs.enlightenment.org/efl/current/>
Traceback (most recent call last):
  File
  "/Users/redox/dev/Algolia/documentation-scrapper/env3/lib/python3.5/site-packages/twisted/internet/defer.py",
  line 1126, in _inlineCallbacks
      result = result.throwExceptionIntoGenerator(g)
        File
        "/Users/redox/dev/Algolia/documentation-scrapper/env3/lib/python3.5/site-packages/twisted/python/failure.py",
        line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
              File
              "/Users/redox/dev/Algolia/documentation-scrapper/env3/lib/python3.5/site-packages/scrapy/core/downloader/middleware.py",
              line 43, in process_request
                  defer.returnValue((yield
                  download_func(request=request,spider=spider)))
                  twisted.web._newclient.ResponseNeverReceived:
                  [<twisted.python.failure.Failure OpenSSL.SSL.Error:
                  [('SSL routines', 'ssl3_read_bytes', 'ssl handshake
                  failure')]>]
```
