### PR TITLE
Add instructions for running the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 crawling_data
 node_modules
 checker/node_modules
-src/.cache/
+.cache
 src/__pycache__/
 src/strategies/__pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -145,3 +145,18 @@ To do this you need to override them when running the cli tool:
 ```
 APPLICATION_ID= API_KEY= ./docsearch deploy:configs
 ```
+
+## Run the tests
+
+### With docker
+
+```sh
+$ ./docsearch test
+```
+
+### Without docker
+
+```sh
+$ pip install pytest 
+$ API_KEY='test' APPLICATION_ID='test' python -m pytest
+```


### PR DESCRIPTION
* Provide instructions for running tests with or without docker
* Ignore the pytest cache from all directories
* Ensure the user environnement is not use in the tests