### PR TITLE
Check that config.nb_hits_max is set before referencing

### DIFF
--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -26,7 +26,9 @@ def run_config(config):
     config = ConfigLoader(config)
     CustomDownloaderMiddleware.driver = config.driver
     DocumentationSpider.NB_INDEXED = 0
-    DocumentationSpider.NB_HITS_MAX = config.nb_hits_max
+    
+    if config.nb_hits_max:
+        DocumentationSpider.NB_HITS_MAX = config.nb_hits_max
 
     if config.use_anchors:
         from . import scrapy_patch


### PR DESCRIPTION
hopefully this fixes the nice error I'm seeing:

AttributeError: 'ConfigLoader' object has no attribute 'nb_hits_max'