### PR TITLE
Enable DocSearch to scrape alternate languages in sitemap

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -61,6 +61,7 @@ class ConfigLoader(object):
 
     driver = None
 
+    sitemap_alternate_links = False
     sitemap_urls = []
     sitemap_urls_regexs = []
     force_sitemap_urls_crawling = False

--- a/scraper/src/config/config_validator.py
+++ b/scraper/src/config/config_validator.py
@@ -33,6 +33,9 @@ class ConfigValidator(object):
         if self.config.use_anchors and not isinstance(self.config.use_anchors, bool):
             raise Exception('use_anchors should be boolean')
 
+        if self.config.sitemap_alternate_links and not isinstance(self.config.sitemap_alternate_links, bool):
+            raise Exception('sitemap_alternate_links should be boolean')
+
         if self.config.sitemap_urls_regexs and not self.config.sitemap_urls:
             raise Exception('You gave an regex to parse sitemap but you didn\'t provide a sitemap url')
 

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -109,7 +109,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
                 print "Neither start url nor regex: default, we scrap all"
                 sitemap_rules = [('.*', 'parse_from_sitemap')]
 
-            self.__init_sitemap_(config.sitemap_urls, sitemap_rules)
+            self.__init_sitemap_(config.sitemap_urls, sitemap_rules, config.sitemap_alternate_links)
             self.force_sitemap_urls_crawling = config.force_sitemap_urls_crawling
         # END _init_ part from SitemapSpider
         super(DocumentationSpider, self)._compile_rules()
@@ -222,9 +222,9 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
 
                 # Other check available such as DNSLookupError, TimeoutError, TCPTimedOutError)...
 
-    def __init_sitemap_(self, sitemap_urls, custom_sitemap_rules):
+    def __init_sitemap_(self, sitemap_urls, custom_sitemap_rules, sitemap_alternate_links):
         """Init method of a SiteMapSpider @Scrapy"""
-        self.sitemap_alternate_links = True
+        self.sitemap_alternate_links = sitemap_alternate_links
         self.sitemap_urls = sitemap_urls
         self.sitemap_rules = custom_sitemap_rules
         self._cbs = []

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -224,6 +224,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
 
     def __init_sitemap_(self, sitemap_urls, custom_sitemap_rules):
         """Init method of a SiteMapSpider @Scrapy"""
+        self.sitemap_alternate_links = True
         self.sitemap_urls = sitemap_urls
         self.sitemap_rules = custom_sitemap_rules
         self._cbs = []


### PR DESCRIPTION
# Summary

A lot of algolia docsearch users are Docusaurus users. For example: Docusaurus, React Native, Jest, Prettier, Reasonml, Babel and many more.

In Docusaurus, we implement the sitemap for docs with multiple languages according to [google's spec](https://support.google.com/webmasters/answer/189077?hl=en&visit_id=1-636663918916415691-3337098161&rd=1)

<img width="745" alt="google spec" src="https://user-images.githubusercontent.com/17883920/42427028-d996148c-835e-11e8-8ebd-ba54017db68c.PNG">

According to https://github.com/facebook/Docusaurus/issues/826, algolia docsearch is unable to scrape alternate_url, but this can simply be fixed by enabling `sitemap_alternate_links` since the scraper is based on Scrapy 1.4

https://github.com/algolia/docsearch-scraper/blob/df13ac5d9ff6f684a4d2fb4623625bc05ce3ab5b/requirements.txt#L33

Referring to https://doc.scrapy.org/en/1.4/topics/spiders.html#scrapy.spiders.SitemapSpider.sitemap_alternate_links

> **sitemap_alternate_links**
> Specifies if alternate links for one url should be followed. These are links for the same website in another language passed within the same url block.
> For example:
> ```
> <url>
>     <loc>http://example.com/</loc>
>     <xhtml:link rel="alternate" hreflang="de" href="http://example.com/de"/>
> </url>
> ```
> Default is sitemap_alternate_links disabled.

Scrapy actually allow the scraping of alternate urls, we just need to enable it because it is set to false on Default.

https://github.com/scrapy/scrapy/blob/5f69ec98f70e1e1e5f65fb36eb1cfb23d0be5b45/scrapy/spiders/sitemap.py#L19
```py
class SitemapSpider(Spider):
    sitemap_urls = ()
    sitemap_rules = [('', 'parse')]
    sitemap_follow = ['']
    sitemap_alternate_links = False
```

There is also a test for it on Scrapy
https://github.com/scrapy/scrapy/blob/5f69ec98f70e1e1e5f65fb36eb1cfb23d0be5b45/tests/test_utils_sitemap.py#L181-L201

```py
    def test_alternate(self):
        s = Sitemap(b"""<?xml version="1.0" encoding="UTF-8"?>
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
        xmlns:xhtml="http://www.w3.org/1999/xhtml">
        <url>
            <loc>http://www.example.com/english/</loc>
            <xhtml:link rel="alternate" hreflang="de"
                href="http://www.example.com/deutsch/"/>
            <xhtml:link rel="alternate" hreflang="de-ch"
                href="http://www.example.com/schweiz-deutsch/"/>
            <xhtml:link rel="alternate" hreflang="en"
                href="http://www.example.com/english/"/>
            <xhtml:link rel="alternate" hreflang="en"/><!-- wrong tag without href -->
        </url>
    </urlset>""")


        self.assertEqual(list(s), [
            {'loc': 'http://www.example.com/english/',
             'alternate': ['http://www.example.com/deutsch/', 'http://www.example.com/schweiz-deutsch/', 'http://www.example.com/english/']
            }
        ])
```

cc @s-pace @yangshun @joelmarcey