### PR TITLE
consistent print

### DIFF
--- a/cli/src/commands/bootstrap_config.py
+++ b/cli/src/commands/bootstrap_config.py
@@ -39,7 +39,7 @@ class BootstrapConfig(AbstractCommand):
             file.write(self.config_to_s(config))
             file.close()
 
-            print file_path + " has been created"
+            print(file_path + " has been created")
 
     def config_to_s(self, config):
         import json


### PR DESCRIPTION
Making a print statement consistent with the rest of the file. 
Also without this python 3 blows up e.g

```
Traceback (most recent call last):
  File "./docsearch", line 3, in <module>
    from cli.src.index import run
  File "/private/tmp/test/docsearch-scraper/cli/src/index.py", line 15, in <module>
    from .commands.bootstrap_config import BootstrapConfig
  File "/private/tmp/test/docsearch-scraper/cli/src/commands/bootstrap_config.py", line 42
    print file_path + " has been created"
                  ^
SyntaxError: Missing parentheses in call to 'print'
```