### PR TITLE
updating user_agent for crawl made without js_rendering

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -50,7 +50,7 @@ class ConfigLoader(object):
     strict_redirect = True
     strip_chars = u".,;:§¶"
     use_anchors = False
-    user_agent = 'Algolia Docsearch Crawler'
+    user_agent = 'Algolia DocSearch Crawler'
     only_content_level = False
     query_rules = []
 

--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -50,7 +50,7 @@ class ConfigLoader(object):
     strict_redirect = True
     strip_chars = u".,;:§¶"
     use_anchors = False
-    user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/70.0.3538.110 Safari/537.36'
+    user_agent = 'Algolia Docsearch Crawler'
     only_content_level = False
     query_rules = []
 


### PR DESCRIPTION
This user_agent will help sysadmin to identify our crawler.

When `js_render` is not set, out user_agent will be `Algolia DocSearch Crawler`.
When `js_render` is set to true, the user_agent is currently `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/71.0.3578.98 Safari/537.36`

This will partially resolves https://github.com/algolia/docsearch-scraper/issues/404