### PR TITLE
fix: use the right email to create the fingerprint of a page

### DIFF
--- a/scraper/src/custom_dupefilter.py
+++ b/scraper/src/custom_dupefilter.py
@@ -29,7 +29,7 @@ class CustomDupeFilter(RFPDupeFilter):
         if remove_scheme:
             match_capture_any_scheme = r'(https?)(.*)'
             url_for_hash = re.sub(match_capture_any_scheme, r"\2",
-                                  url_for_hash)
+                                  url_for_finger_print)
 
         if include_headers:
             include_headers = tuple(to_bytes(h.lower())

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -52,7 +52,6 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
     def to_other_scheme(url):
         """Return a list with the translation to this url into each other scheme."""
         other_scheme_urls = []
-        url = url.encode('utf8')
         match = DocumentationSpider.match_capture_any_scheme.match(url)
         assert match
         if not (match and match.group(1) and match.group(2)):


### PR DESCRIPTION
It fixes custom_dupefilter way of handling URL