### PR TITLE
Deploy image before porting to python v3

### DIFF
--- a/cli/src/commands/abstract_build_docker.py
+++ b/cli/src/commands/abstract_build_docker.py
@@ -8,7 +8,7 @@ class AbstractBuildDocker(AbstractCommand):
         tags = [image]
 
         if local_tag:
-            tag = AbstractBuildDocker.get_local_tag()
+            tag = AbstractBuildDocker.get_local_tag().decode()
             tags.append(image + ":" + tag)
 
         cmd = ["docker", "build"] + [param for tag in tags for param in

--- a/scraper/dev/docker/Dockerfile.base
+++ b/scraper/dev/docker/Dockerfile.base
@@ -13,7 +13,8 @@ RUN chown -R seleuser /home/seleuser
 RUN chgrp -R seleuser /home/seleuser
 
 RUN apt-get update -y && apt-get install -yq \
-    software-properties-common
+    software-properties-common\
+    python3.7
 RUN add-apt-repository -y ppa:openjdk-r/ppa
 RUN apt-get update -y && apt-get install -yq \
     curl \


### PR DESCRIPTION
This PR deploys the new image using python v3. Changes are here to backup the full v3 porting