### PR TITLE
Fix IAP authentication

### DIFF
--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -15,6 +15,7 @@ import os
 
 # Import for GCP IAP auth
 import json
+import requests
 from requests_iap import IAPAuth
 
 from scrapy.spidermiddlewares.httperror import HttpError
@@ -138,7 +139,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
                 service_account_secret_dict=json.loads(
                     os.getenv("IAP_AUTH_SERVICE_ACCOUNT_JSON")
                 ),
-            )().headers["Authorization"]
+            )(requests.Request()).headers["Authorization"]
             headers = {"Authorization": iap_token}
 
         # We crawl according to the sitemap


### PR DESCRIPTION
Apologies for the stupid mistake introduced, but https://github.com/kiwicom/requests-iap/blob/master/requests_iap/iapauth.py#L56 expects `r` in the `__call__`. 

This should address the issue.