### PR TITLE
docker: add .dockerignore to prevent sharing sensitive data or useless files into the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+.DS_Store
+crawling_data
+node_modules
+checker/node_modules
+.cache
+src/__pycache__/
+src/strategies/__pycache__/
+*.pyc
+.env
+update.sh
+
+*yarn.lock
+
+# IDE Files
+.idea/
+*.iml
+geckodriver.log
+.vscode/
+
+configs/public
+configs/private


### PR DESCRIPTION
The CLI wrap the `docker build` command. Docker context is the root of this project. `.dockerignore` reflects `.gitignore`