### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ In case of Google Cloud Identity-Aware Proxy, please specify these env variables
 - `IAP_AUTH_CLIENT_ID` - # pick [client ID of the application](https://console.cloud.google.com/apis/credentials) you are connecting to
 - `IAP_AUTH_SERVICE_ACCOUNT_JSON` - # generate in [Actions](https://console.cloud.google.com/iam-admin/serviceaccounts) -> Create key -> JSON
 
+Basic HTTP auth is also supported by setting these env variables:
+- `BASIC_AUTH_USERNAME`
+- `BASIC_AUTH_PASSWORD`
+
 ### Installing Chrome Headless
 
 Websites that need JavaScript for rendering are passed through ChromeDriver.

--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -3,6 +3,7 @@ DocSearch scraper main entry point
 """
 import os
 import json
+import base64
 import requests
 from requests_iap import IAPAuth
 
@@ -71,6 +72,10 @@ def run_config(config):
             ),
         )(requests.Request()).headers["Authorization"]
         headers.update({"Authorization": iap_token})
+    elif os.getenv("BASIC_AUTH_USERNAME") and os.getenv("BASIC_AUTH_PASSWORD"):
+        auth_str = f"{os.getenv('BASIC_AUTH_USERNAME')}:{os.getenv('BASIC_AUTH_PASSWORD')}"
+        b64_auth_str = base64.b64encode(auth_str.encode()).decode()
+        headers.update({"Authorization": f"Basic {b64_auth_str}"})
 
     DEFAULT_REQUEST_HEADERS = headers
 


### PR DESCRIPTION
I needed this for crawling an internal site and thought it may be widely usable as well. I understand that indexing public sites is the main point of docsearch, but it seems that you support internal sites somewhat.

Thanks for the great software!