### PR TITLE
feat(headless_chrome): use google chrome 78

### DIFF
--- a/scraper/dev/docker/Dockerfile.base
+++ b/scraper/dev/docker/Dockerfile.base
@@ -34,9 +34,9 @@ RUN apt-get update -y && apt-get install -yq \
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -y && apt-get install -yq \
-  google-chrome-stable \
+  google-chrome-stable=78.0.3904.108-1 \
   unzip
-RUN wget -q https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+RUN wget -q https://chromedriver.storage.googleapis.com/78.0.3904.105/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip
 
 RUN mv chromedriver /usr/bin/chromedriver


### PR DESCRIPTION
This PR:
- use google chrome 78
- enforce the version of `google-chrome-stable` used so that it doesn't depend of the time when we build the docker image which ends up with a fatal error due to an incompatibility between chrome & the driver.

We will release a new version of the scraper that will be pushed to docker HUB.(v1.5.0 and latest)

Closes #478 