### PR TITLE
feat(meta): do not jsonized version meta

### DIFF
--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -177,7 +177,7 @@ class DefaultStrategy(AbstractStrategy):
                         record[name] = content
 
                     if name == "version":
-                        record[name] = str(record[name])
+                        record[name] = str(content)
 
             if current_page_url is not None:
                 # Add variables to the record

--- a/scraper/src/tests/default_strategy/meta_test.py
+++ b/scraper/src/tests/default_strategy/meta_test.py
@@ -216,6 +216,7 @@ class TestMeta:
 
         assert len(actual) == 2
         assert actual[0]['version'] == "5.20"
+        assert actual[0]['version'] != "5.2"
         assert actual[1]['version'] != 5.2
 
     def test_meta_escaped_string(self):

--- a/scraper/src/tests/default_strategy/meta_test.py
+++ b/scraper/src/tests/default_strategy/meta_test.py
@@ -187,6 +187,37 @@ class TestMeta:
         assert actual[0]['version'] == "1.0"
         assert actual[1]['version'] != 1
 
+    def test_meta_decimal_version(self):
+        # Given
+        strategy = get_strategy({
+            'selectors': {
+                'lvl0': "h1",
+                'content': 'p'
+            }
+        })
+        strategy.dom = lxml.html.fromstring("""
+        <html>
+            <header>
+                <meta name="docsearch:version" content='5.20'>
+            </header>
+            <body>
+                <h1>Foo</h1>
+                <p>text</p>
+                <h2>Bar</h2>
+                <h3>Baz</h3>
+            </body>
+        </html>
+        """)
+
+        # When
+        actual = strategy.get_records_from_dom()
+
+        # Then
+
+        assert len(actual) == 2
+        assert actual[0]['version'] == "5.20"
+        assert actual[1]['version'] != 5.2
+
     def test_meta_escaped_string(self):
         # Given
         strategy = get_strategy({


### PR DESCRIPTION
This change will make sure we do not wrongly truncate number. Issue impacting one of our user.

Example of the issue: 5.20 being truncated into 5.2