### PR TITLE
feat: update chrome to 83.0.4103.61

### DIFF
--- a/scraper/dev/docker/Dockerfile.base
+++ b/scraper/dev/docker/Dockerfile.base
@@ -34,9 +34,9 @@ RUN apt-get update -y && apt-get install -yq \
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -y && apt-get install -yq \
-  google-chrome-stable=78.0.3904.108-1 \
+  google-chrome-stable=83.0.4103.61-1 \
   unzip
-RUN wget -q https://chromedriver.storage.googleapis.com/78.0.3904.105/chromedriver_linux64.zip
+RUN wget -q https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip
 
 RUN mv chromedriver /usr/bin/chromedriver


### PR DESCRIPTION
This PR update the headless chrome used to render JS. This is required since apt-get doesn't provide anymore the previous version used. It solves the defective docker build.

Resolves #508