### PR TITLE
generator(vuepress): use correct naming of scrape_start_urls

### DIFF
--- a/deployer/src/config_creator.py
+++ b/deployer/src/config_creator.py
@@ -223,7 +223,7 @@ def to_vuepress_config(config):
     ))
     config["selectors_exclude"] = [".table-of-contents"]
 
-    config["scrap_start_urls"] = False
+    config["scrape_start_urls"] = False
     config["strip_chars"] = " .,;:#"
 
     return config


### PR DESCRIPTION
This PR make sure to generate proper config setting for vuepress websites.

This PR only impacts the tooling used by the DocSearch team. It will not imply a new release of the scraper.

Follows algolia/docsearch-scraper#341