### PR TITLE
refactor(dockerfile): remove deprecated instructions

### DIFF
--- a/scraper/dev/docker/Dockerfile
+++ b/scraper/dev/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM algolia/docsearch-scraper-base
-MAINTAINER Algolia <documentationsearch@algolia.com>
+LABEL maintainer="docsearch@algolia.com"
 
 WORKDIR /root
 COPY scraper/src ./src

--- a/scraper/dev/docker/Dockerfile.base
+++ b/scraper/dev/docker/Dockerfile.base
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER Algolia <documentationsearch@algolia.com>
+LABEL maintainer="docsearch@algolia.com"
 
 WORKDIR /root
 

--- a/scraper/dev/docker/Dockerfile.dev
+++ b/scraper/dev/docker/Dockerfile.dev
@@ -3,4 +3,4 @@
 # - Do not define an ENTRYPOINT
 
 FROM algolia/docsearch-scraper-base
-MAINTAINER Algolia <documentationsearch@algolia.com>
+LABEL maintainer="docsearch@algolia.com"

--- a/scraper/dev/docker/Dockerfile.test
+++ b/scraper/dev/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 FROM algolia/docsearch-scraper-base
-MAINTAINER Algolia <documentationsearch@algolia.com>
+LABEL maintainer="docsearch@algolia.com"
 
 WORKDIR /root
 

--- a/scraper/dev/docker/Dockerfile.test
+++ b/scraper/dev/docker/Dockerfile.test
@@ -5,5 +5,5 @@ WORKDIR /root
 
 # Copy DocSearch files
 COPY . .
-run touch .env
+RUN touch .env
 ENTRYPOINT ["pipenv", "run", "./docsearch", "test", "no_browser"]


### PR DESCRIPTION
This PR removes deprecated MAINTAINER instructions and use correct case for instruction

This PR only impacts the tooling used by the DocSearch team. It will not imply a new release of the scraper.