### PR TITLE
test: add test on empty text element

### DIFF
--- a/scraper/src/tests/default_strategy/get_records_from_dom_test.py
+++ b/scraper/src/tests/default_strategy/get_records_from_dom_test.py
@@ -523,3 +523,22 @@ class TestGetRecordsFromDom:
 
         # Then
         assert len(actual) == 3
+
+    def test_text_with_empty_content(self):
+        # Given
+        strategy = get_strategy()
+
+        strategy.dom = lxml.html.fromstring("""
+            <html><body>
+                <h1>Foo</h1>
+                <h2>Bar</h2>
+                <h3>Baz</h3>
+                <p></p>
+            </body></html>
+            """)
+
+        # When
+        actual = strategy.get_records_from_dom()
+
+        # Then
+        assert len(actual) == 3


### PR DESCRIPTION
This PR makes sure to test the default strategy. We do not index record when text element is empty.

Resolves #361

This PR only impacts the test suite of the scraper. It doesn't bring any new feature. It will not imply a new release of the scraper.