### PR TITLE
fix: add config_exists to the command in order to add a new api key

### DIFF
--- a/cli/src/commands/deploy_config.py
+++ b/cli/src/commands/deploy_config.py
@@ -11,6 +11,7 @@ class DeployConfig(AbstractCommand):
     def get_options(self):
         return [{"name": "index_name",
                  "description": "name of the config to deploy"},
+                 {"name": "config_exists", "description": "the config is already in the repo"},
                  {"name": "push_config", "description": "push the config to master", "optional": True}]
 
     def run(self, args):
@@ -20,4 +21,4 @@ class DeployConfig(AbstractCommand):
             exit(1)
         else:
             from deployer.src.index import deploy_config
-            deploy_config(args[0], args[1] if len(args) > 1 else True)
+            deploy_config(args[0], args[1], args[2] if len(args) > 2 else True)

--- a/deployer/src/index.py
+++ b/deployer/src/index.py
@@ -3,7 +3,6 @@ import os
 
 from . import helpers
 from .config_manager import ConfigManager
-from . import fetchers
 
 
 def print_init():

--- a/deployer/src/index.py
+++ b/deployer/src/index.py
@@ -21,7 +21,7 @@ def print_init():
     print("")
 
 
-def deploy_config(config_name, push_config=True):
+def deploy_config(config_name, config_exists, push_config=True):
     from os import environ, path
 
     print_init()
@@ -38,7 +38,7 @@ def deploy_config(config_name, push_config=True):
         print("Folder: " + config_folder + " does not exist")
         exit()
 
-    config_exists = config_name in fetchers.get_configs_from_repos()
+    # config_exists = config_name in fetchers.get_configs_from_repos()
 
     if push_config == True:
         # Not using the config manager to avoid it stashing the config that we want to push


### PR DESCRIPTION
When publishing a config after has been reviewed, since it exists already in the repo, the api key will not be created