### PR TITLE
Added auth cookie support in .env

### DIFF
--- a/scraper/src/custom_downloader_middleware.py
+++ b/scraper/src/custom_downloader_middleware.py
@@ -10,9 +10,11 @@ from urllib.parse import urlparse, unquote_plus
 
 class CustomDownloaderMiddleware:
     driver = None
+    auth_cookie = None
 
     def __init__(self):
         self.driver = CustomDownloaderMiddleware.driver
+        self.initialized_auth = False
 
     def process_request(self, request, spider):
         if not spider.js_render:
@@ -22,6 +24,11 @@ class CustomDownloaderMiddleware:
             o = urlparse(request.url)
             url_without_params = o.scheme + "://" + o.netloc + o.path
             request = request.replace(url=url_without_params)
+
+        if self.auth_cookie and not self.initialized_auth:
+            self.driver.get(unquote_plus(request.url))
+            self.driver.add_cookie(self.auth_cookie)
+            self.initialized_auth = True
 
         print("Getting " + request.url + " from selenium")
 

--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -72,6 +72,13 @@ def run_config(config):
 
     DEFAULT_REQUEST_HEADERS = headers
 
+    if os.getenv('AUTH_COOKIE_NAME') and os.getenv('AUTH_COOKIE_VALUE'):
+        auth_cookie = {
+            'name': os.getenv('AUTH_COOKIE_NAME'),
+            'value': os.getenv('AUTH_COOKIE_VALUE'),
+        }
+        CustomDownloaderMiddleware.auth_cookie = auth_cookie
+
     process = CrawlerProcess({
         'LOG_ENABLED': '1',
         'LOG_LEVEL': 'ERROR',


### PR DESCRIPTION
Allows chrome webdriver to authenticate using an auth cookie pulled from the .env file. This would allow for scraping of password-protected documentation.