### PR TITLE
refactor(Dockerfile): use latest stable chrome with matching driver

### DIFF
--- a/scraper/dev/docker/Dockerfile.base
+++ b/scraper/dev/docker/Dockerfile.base
@@ -34,9 +34,12 @@ RUN apt-get update -y && apt-get install -yq \
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -y && apt-get install -yq \
-  google-chrome-stable=85.0.4183.102-1 \
+  google-chrome-stable \
   unzip
-RUN wget -q https://chromedriver.storage.googleapis.com/85.0.4183.83/chromedriver_linux64.zip
+
+RUN CHROME_VERSION=$(google-chrome --version | grep -oE "[0-9.]{9}") && \
+    CHROMEDRIVER_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) && \
+    wget -q https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip
 
 RUN mv chromedriver /usr/bin/chromedriver


### PR DESCRIPTION
Pinning `google-chrome-stable` is not the easiest as versions are removed from time to time as the newer versions usually become the stable ones.

I've seen efforts in bumping the Chrome versions manually a couple of times:
- https://github.com/algolia/docsearch-scraper/commit/1169b0b8d926ed098026f01ccccae6423607d8d9#diff-3bb4f830690e6edb8b6b97c62ef18eae8af2a6b1c5aeb08aaf921c2a22692ef7
- https://github.com/algolia/docsearch-scraper/commit/d8e72b812ea418e99671bebd5a9d454e003d161e#diff-3bb4f830690e6edb8b6b97c62ef18eae8af2a6b1c5aeb08aaf921c2a22692ef7
- ...

So in order to avoid issues like [this](https://github.com/algolia/docsearch-scraper/issues/456) in the future, always install the latest stable version of Google Chrome as well as the matching ChromeDriver according to their own [documentation](https://chromedriver.chromium.org/downloads/version-selection).