### PR TITLE
fix(strategies): replace deprecated `attributesToIndex` by `searchableAttributes`

### DIFF
--- a/scraper/src/strategies/algolia_settings.py
+++ b/scraper/src/strategies/algolia_settings.py
@@ -6,35 +6,35 @@ class AlgoliaSettings:
 
     @staticmethod
     def get(config, levels):
-        attributes_to_index = []
+        searchable_attributes = []
 
         # We first look for matches in the exact titles
         for level in levels:
             for selectors_key in config.selectors:
                 attr_to_index = 'unordered(hierarchy_radio.' + level + ')'
                 if level in config.selectors[
-                    selectors_key] and attr_to_index not in attributes_to_index:
-                    attributes_to_index.append(
+                    selectors_key] and attr_to_index not in searchable_attributes:
+                    searchable_attributes.append(
                         'unordered(hierarchy_radio_camel.' + level + ')')
-                    attributes_to_index.append(attr_to_index)
+                    searchable_attributes.append(attr_to_index)
 
         # Then in the whole title hierarchy
         for level in levels:
             for selectors_key in config.selectors:
                 attr_to_index = 'unordered(hierarchy.' + level + ')'
                 if level in config.selectors[
-                    selectors_key] and attr_to_index not in attributes_to_index:
-                    attributes_to_index.append(
+                    selectors_key] and attr_to_index not in searchable_attributes:
+                    searchable_attributes.append(
                         'unordered(hierarchy_camel.' + level + ')')
-                    attributes_to_index.append(attr_to_index)
+                    searchable_attributes.append(attr_to_index)
 
         for selectors_key in config.selectors:
             if 'content' in config.selectors[
-                selectors_key] and 'content' not in attributes_to_index:
-                attributes_to_index.append('content')
+                selectors_key] and 'content' not in searchable_attributes:
+                searchable_attributes.append('content')
 
         settings = {
-            'attributesToIndex': attributes_to_index,
+            'searchableAttributes': searchable_attributes,
             'attributesToRetrieve': [
                 'hierarchy',
                 'content',

--- a/scraper/src/tests/default_strategy/get_settings_test.py
+++ b/scraper/src/tests/default_strategy/get_settings_test.py
@@ -35,4 +35,4 @@ class TestGetSettings:
             'content'
         ]
 
-        assert settings['attributesToIndex'] == expected_settings
+        assert settings['searchableAttributes'] == expected_settings


### PR DESCRIPTION
**Summary**

Following https://github.com/algolia/docsearch-scraper/pull/544, `attributesToIndex` was still in the codebase but unused in our configs, which causes errors if needed.

**Result**

We now use the new naming: `searchableAttributes`